### PR TITLE
style(ui): colorize primary and secondary buttons

### DIFF
--- a/templates/add.html
+++ b/templates/add.html
@@ -11,8 +11,8 @@
         <input type="text" id="date_iso" name="date_iso" placeholder="=例：202-01-23">
 
         <div>
-            <button class="btn primary" type="submit">登録</button>
-            <a class="btn" href="{{ url_for('index') }}">トップへ</a>
+            <button class="btn success" type="submit">登録</button>
+            <a class="btn secondary" href="{{ url_for('index') }}">トップへ</a>
         </div>
     </form>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,6 +21,10 @@
             input[type="text"] { width: 260px; padding: 6px; }
             .btn { display: inline-block; padding: 8px 12px; margin: 6px 8px 0 0; border: 1px solid #ccc; border-radius: 6px; text-decoration: none; color: #333; }
             .btn.primary { background: #f0f7ff; border-color: #a3c8ff; }
+            .btn.success { background: #e6f6e6; border-color: #9f8fd2; color: #d7119b; }
+            .btn.secondary { background: #f4f4f4; border-color: #cccccc; color: #333333; }
+            .btn.denger { background: #ffecec; border-color: #ffb3b3; color: #a30000; }
+
         </style>
     </head>
     <body>
@@ -28,7 +32,7 @@
             <h1>date-tracker</h1>
             <nav>
                 <a class="btn" href="{{ url_for('index') }}">トップ</a>
-                <a class="btn" href="{{ url_for('add') }}">登録</a>
+                <a class="btn success" href="{{ url_for('add') }}">登録</a>
                 <a class="btn" href="{{ url_for('list_view') }}">一覧</a>
                 <a class="btn" href="{{ url_for('elapsed') }}">経過日</a>
             </nav>


### PR DESCRIPTION
## 目的
主要アクションと補助アクションの視覚的区別をつけ、可読性を向上。

## 変更点
- base.html に .btn.success / .btn.secondary / .btn.danger を追加
- add.html の「登録」を success、「トップへ」を secondary に変更

## 動作確認
- /add で色分けが適用されること
- 登録フローとフラッシュ表示に影響がないこと