### PR TITLE
feat(ui): card layout on home (index) with subtle hover

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -35,6 +35,36 @@
 
             /* --- スマホで横スクロールできるように --- */
             .table-wrap { overflow-x: auto; }
+
+            /* --- cards on home --- */
+            .cards {
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+                gap: 16px;
+                margin-top: 12px;
+            }
+            .card {
+                border: 1px solid #e5e7eb;
+                border-radius: 12px;
+                padding: 16px;
+                background: #fff;
+                box-shadow: 0 2px 8px rgba(0,0,0,.04);
+                transition: transform .12s ease, box-shadow .12s ease;
+            }
+            .card:hover {
+                transform: translateY(-2px);
+                box-shadow: 0 6px 18px rgba(0,0,0,.08);
+            }
+            .card h3 {
+                margin: 0 0 8px;
+                font-size: 18px;
+            }
+            .card p {
+                margin: 0 0 12px;
+                color: #555;
+                font-size: 14px;
+            }
+            .card .actions .btn { margin-right: 8px; }
         </style>
     </head>
     <body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,10 +3,27 @@
 {% extends "base.html" %}
 {% block content %}
     <h2>メニュー</h2>
-    <p>「登録」「一覧」「経過日」をブラウザで操作できます。</p>
-    <p>
-        <a class="btn primary" href="{{ url_for('add') }}">登録</a>
-        <a class="btn primary" href="{{ url_for('list_view') }}">一覧</a>
-        <a class="btn primary" href="{{ url_for('elapsed') }}">経過日</a>
-    </p>
+    <div class="cards">
+        <div class="card">
+            <h3>登録</h3>
+            <p>タイトルと日付を追加します。</p>
+            <div class="actions">
+                <a class="btn success" href="{{ url_for('add') }}">登録へ</a>
+            </div>
+        </div>
+        <div class="card">
+            <h3>一覧</h3>
+            <p>登録済みのデータを一覧表示します。</p>
+            <div class="actions">
+                <a class="btn" href="{{ url_for('list_view') }}">一覧を見る</a>
+            </div>
+        </div>
+        <div class="card">
+            <h3>経過日</h3>
+            <p>指定日までの残り/経過日数を計算します。</p>
+            <div class="actions">
+                <a class="btn" href="{{ url_for('elapsed') }}">計算へ</a>
+            </div>
+        </div>
+    </div>
 {% endblock %}


### PR DESCRIPTION
## 目的
トップページの視認性を高め、3機能への導線をわかりやすくする。

## 変更点
- base.html: カード用のCSSを追加
- index.html: メニューをカードレイアウト化

## 動作確認
- / でカード3枚が表示される
- ホバーで軽く浮く
- 各ボタンから /add /list /elapsed へ遷移可能