### PR TITLE
feat(ui): date inputs with calendar icon (type=date + styled)

### DIFF
--- a/templates/add.html
+++ b/templates/add.html
@@ -8,7 +8,7 @@
         <input type="text" id ="name" name="name" placeholder="例：電池交換">
 
         <label for="date_iso">日付（YYYY-MM-DD）</label>
-        <input type="text" id="date_iso" name="date_iso" placeholder="=例：202-01-23">
+        <input type="date" id="date_iso" name="date_iso" class="input-date" placeholder="=例：202-01-23" required>
 
         <div>
             <button class="btn success" type="submit">登録</button>

--- a/templates/base.html
+++ b/templates/base.html
@@ -107,6 +107,22 @@
             @media (max-width: 480px) {
             .logo { font-size: 44px; }  /* モバイル時は約1.5倍相当に抑える */
             }
+
+            /* --- date input with calender icon --- */
+            .input-date {
+                appearance: none;
+                -webkit-appearance: none;
+                background: #fff url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="%23666"><path d="M5 2a1 1 0 1 1 2 0v1h4V2a1 1 0 1 1 2 0v1h1.5A1.5 1.5 0 0 1 16 4.5v10A1.5 1.5 0 0 1 14.5 16h-11A1.5 1.5 0 0 1 2 14.5v-10A1.5 1.5 0 0 1 3.5 3H5V2ZM3.5 6v8h11V6h-11Z"/></svg>') no-repeat right 10px center;
+                background-size: 18px 18px;
+                padding-right: 40px;
+                border: 1px solid #ccc;
+                border-radius: 6px;
+                padding: 6px 10px;
+                width: 260px;
+            }
+            .input-date::after::after-webkit-calendar-picker-indicator {
+                opacity: 0;
+            }
         </style>
     </head>
     <body>

--- a/templates/elapsed.html
+++ b/templates/elapsed.html
@@ -8,7 +8,7 @@
         <input type="text" id="name" name="name" placeholder="例：電池交換">
 
         <label for="on_date">比較日（YYYY-MM-DD）</label>
-        <input type="text" id="on_date" name="on_date" placeholder="例：202-01-23">
+        <input type="date" id="on_date" name="on_date" class="input-date" placeholder="例：202-01-23" required>
 
         <div>
             <button class="btn primary" type="submit">計算</button>


### PR DESCRIPTION
## 目的
日付入力の誤りを減らし、入力体験を向上。

## 変更点
- base.html: .input-date を追加（カレンダーアイコン、余白、枠線）
- add.html / elapsed.html: input[type=date] + .input-date に変更

## 動作確認
- /add と /elapsed で日付ピッカーが開く
- サーバ側バリデーションは従来通り（YYYY-MM-DD）