### PR TITLE
feat: delete entry form list view (POST /delete/<name>)

### DIFF
--- a/app_web.py
+++ b/app_web.py
@@ -96,6 +96,7 @@
 
 from __future__ import annotations
 from flask import Flask, render_template, request, redirect, url_for, flash
+from tracker_core import load_json, save_json, save_csv
 import os
 import tracker_core as core
 
@@ -162,6 +163,26 @@ def list_view():
     sorted_names = sorted(records.keys())
     rows = [(n, records[n]) for n in sorted_names]
     return render_template("list.html", records=rows, count=count)
+
+@app.post("/delete/<name>")
+def delete_entry(name: str):
+    name = name.strip()
+    if not name:
+        flash("削除対象の名前がからです。", "error")
+        return redirect(url_for("list_view"))
+    
+    records = load_json(JSON_PATH)
+    if name not in records:
+        flash(f"「{name}」は見つかりません。", "error")
+        return redirect(url_for("list_view"))
+    
+    del records[name]
+    save_json(records, JSON_PATH)
+    save_csv(records, CSV_PATH)
+
+    flash(f"「{name}」を削除しました。", "success")
+    return redirect(url_for("list_view"))
+
 
 @app.route("/elapsed", methods=["GET", "POST"])
 def elapsed():

--- a/templates/list.html
+++ b/templates/list.html
@@ -2,29 +2,39 @@
 
 {% extends "base.html" %}
 {% block content %}
-    <h2>一覧</h2>
+  <h2>一覧</h2>
 
-    {% if not records %}
-        <p>表示できるデータがありません。</p>
-        <p><a class="btn primary" href="{{ url_for('add') }}">登録へ</a></p>
-    {% else %}
-        <div class="table-wrap">
-        <table class="table striped hover compact">
-            <thead>
-            <tr><th>名前</th><th>日付（YYYY-MM-DD）</th></tr>
-            </thead>
-            <tbody>
-            {% for name, date_iso in records %}
-                <tr>
-                <td>{{ name }}</td>
-                <td>{{ date_iso }}</td>
-                </tr>
-            {% endfor %}
-            </tbody>
-        </table>
-        </div>
-        <p>合計 {{ count }} 件</p>
-    {% endif %}
+  {% if not records %}
+    <p>表示できるデータがありません。</p>
+    <p><a class="btn primary" href="{{ url_for('add') }}">登録へ</a></p>
+  {% else %}
+    <div class="table-wrap">
+      <table class="table striped hover compact">
+        <thead>
+          <tr>
+            <th>名前</th>
+            <th>日付（YYYY-MM-DD）</th>
+            <th>操作</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for name, date_iso in records %}
+            <tr>
+              <td>{{ name }}</td>
+              <td>{{ date_iso }}</td>
+              <td>
+                <form method="post" action="{{ url_for('delete_entry', name=name) }}" style="display:inline"
+                      onsubmit="return confirm('「{{ name }}」を削除します。よろしいですか？');">
+                  <button type="submit" class="btn danger">削除</button>
+                </form>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    <p>合計 {{ count }} 件</p>
+  {% endif %}
 
-    <p><a class="btn" href="{{ url_for('index') }}">トップへ</a></p>
+  <p><a class="btn" href="{{ url_for('index') }}">トップへ</a></p>
 {% endblock %}


### PR DESCRIPTION
## 目的
誤登録や不要データの削除をUIから行えるようにする。

## 変更点
- app_web.py: POST /delete/<name> を追加。存在チェック→削除→JSON/CSV保存→flash→/list
- list.html: 操作列を追加し、各行に削除ボタン（confirm付き）を表示

## 動作確認
- /list で削除ボタン押下→確認ダイアログ→削除→フラッシュ表示
- 非存在名・空名はエラーフラッシュで復帰